### PR TITLE
Fixtureが削除されている場合はdeleteのみ実行

### DIFF
--- a/lib/DBIx/FixtureLoader.pm
+++ b/lib/DBIx/FixtureLoader.pm
@@ -189,7 +189,6 @@ sub _load_fixture_from_data {
     my $delete = $self->delete || $args{delete};
 
     $data = $self->_normalize_data($data);
-    return unless @$data;
 
     my $dbh = $self->dbh;
     # needs limit ?
@@ -199,6 +198,8 @@ sub _load_fixture_from_data {
         my ($sql, @binds) = $self->_sql_builder->delete($table);
         $dbh->do($sql, undef, @binds);
     }
+
+    return $txn->commit or croak $dbh->errstr unless scalar @$data;
 
     my $opt; $opt->{prefix} = 'INSERT IGNORE INTO' if $ignore;
     if ($bulk_insert) {
@@ -257,7 +258,7 @@ DBIx::FixtureLoader - Loading fixtures and inserting to your database
 
     use DBI;
     use DBIx::FixtureLoader;
-    
+
     my $dbh = DBI->connect(...);
     my $loader = DBIx::FixtureLoader->new(dbh => $dbh);
     $loader->load_fixture('item.csv');

--- a/t/04_empty.t
+++ b/t/04_empty.t
@@ -42,4 +42,12 @@ $m->load_fixture('t/data/zero.csv', update => 1);
 $result = $dbh->selectrow_arrayref('SELECT COUNT(*) FROM zero ORDER BY id;');
 is $result->[0], 0;
 
+$dbh->do(q{INSERT INTO zero VALUES (101,"Ninja Star");});
+$result = $dbh->selectrow_arrayref('SELECT COUNT(*) FROM zero ORDER BY id;');
+is $result->[0], 1;
+
+$m->load_fixture('t/data/zero.csv', update => 1, delete => 1, bulk_insert => 1);
+$result = $dbh->selectrow_arrayref('SELECT COUNT(*) FROM zero ORDER BY id;');
+is $result->[0], 0;
+
 done_testing;


### PR DESCRIPTION
既存のレコードがある状態でFixtureから全て削除した場合、レコードが削除されない問題を対応しました。

確認をお願いします