### PR TITLE
Avoid warning "Possible precedence issue with control flow operator"

### DIFF
--- a/lib/DBIx/FixtureLoader.pm
+++ b/lib/DBIx/FixtureLoader.pm
@@ -199,7 +199,10 @@ sub _load_fixture_from_data {
         $dbh->do($sql, undef, @binds);
     }
 
-    return $txn->commit or croak $dbh->errstr unless scalar @$data;
+    unless (scalar @$data) {
+        my $ret = $txn->commit or croak $dbh->errstr;
+        return $ret;
+    }
 
     my $opt; $opt->{prefix} = 'INSERT IGNORE INTO' if $ignore;
     if ($bulk_insert) {


### PR DESCRIPTION
Got warning "Possible precedence issue with control flow operator" at over Perl5.20. My PR removes it.

Also works like below:

```
return( $txn->commit or croak $dbh->errstr ) unless scalar @$data;
```

My code is more specific for an error on commit, I think.